### PR TITLE
Increase read_timeout for download operation

### DIFF
--- a/operations/download/run.rb
+++ b/operations/download/run.rb
@@ -33,6 +33,7 @@ puts "[START] download/run.rb from #{url} to #{destination_file_name}"
 
 uri = URI.parse(url)
 http = Net::HTTP.new(uri.host, uri.port)
+http.read_timeout = 500
 if url =~ /\Ahttps/
   http.use_ssl = true
   http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
* Increases `read_timeout` to 500 seconds (default is 60) because some ETL steps which includes downloads of resources from customers API are very slow