### PR TITLE
Accept file-url parameter to provide remote data

### DIFF
--- a/operations/gobierto_data/upload-dataset/run.rb
+++ b/operations/gobierto_data/upload-dataset/run.rb
@@ -41,6 +41,9 @@ BANNER
   opts.on("--file-path FILE_PATH", "Data file path") do |v|
     options[:file_path] = v
   end
+  opts.on("--file-url FILE_URL", "Data file url") do |v|
+    options[:file_url] = v
+  end
   opts.on("--schema-path SCHEMA_PATH", "Schema file path") do |v|
     options[:schema_path] = v
   end


### PR DESCRIPTION
Adds support to `file_url` parameter to load data from a remote source. Example:

```
ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/upload-dataset/run.rb --api-token $API_TOKEN_ADMIN --gobierto-url http://madrid.gobierto.test --name "Calidad aire " --slug aire-getafe --table-name calidad_aire_getafe --file-url https://remote-gobierto-host/api/v1/data/data.csv?sql=select%20*%20from%20calidad_del_aire%20where%20estacion%20=%2014%20limit%2010
```
