### PR TITLE
New command run Oracle query

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ Usage:
 
 `ruby gobierto-etl-utils/operations/prepare-working-directory/run.rb /tmp/foo`
 
+### common/run Oracle query
+
+Runs a query in Oracle using `sqlplus` utility
+
+Usage:
+
+`$DEV_DIR/gobierto-etl-utils/operations/run-oracle-query/run.rb "CONNECTION STRING" input.sql $WORKING_DIR/output.csv`
+
+Where:
+
+- first argument: the connection string
+- second argument: a file with the query to execute
+- third argument: the output file (in CSV format)
+
 ### gobierto-budgets/annual data
 
 Calculates the CSV and JSON files for the open data section of the given sites with the organization ID provided.

--- a/lib/gobierto_etl_utils.rb
+++ b/lib/gobierto_etl_utils.rb
@@ -2,6 +2,8 @@
 
 require "optparse"
 require "csv"
+require "fileutils"
+require "tempfile"
 require "bundler/setup"
 Bundler.require
 

--- a/operations/prepare-working-directory/run.rb
+++ b/operations/prepare-working-directory/run.rb
@@ -2,7 +2,7 @@
 
 require "bundler/setup"
 Bundler.require
-require "fileutils"
+require_relative "../../lib/gobierto_etl_utils"
 
 # Removes the directory and creates it if doesn't exist
 #

--- a/operations/run-oracle-query/run.rb
+++ b/operations/run-oracle-query/run.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require_relative "../../lib/gobierto_etl_utils"
+
+# Runs a query into Oracle and returns the result in a CSV
+# Assumes exists sqlplus command
+#
+# Usage:
+#
+#  - Must be ran as an independent Ruby script
+#
+# Arguments:
+#
+#  - 0: Oracle connection
+#  - 1: Query file
+#  - 2: Output file
+#
+# Samples:
+#
+#   $DEV_DIR/gobierto-etl-utils/operations/run-oracle-query/run.rb "CONNECTION" input.sql $WORKING_DIR/output.csv
+
+if ARGV.length != 3
+  raise "Review the arguments"
+end
+
+# Check sqlplus
+if `which sqlplus` == ""
+  raise "SQLPlus not found"
+end
+
+connection_string = ARGV[0]
+query_filename = ARGV[1]
+destination_name = ARGV[2]
+
+puts "[START] run-oracle-query/run.rb from #{query_filename} to #{destination_name}"
+
+query = File.read(query_filename)
+file = Tempfile.new("oracle-connection")
+file.write "#{connection_string}\nset markup csv on;\n#{query}\n"
+file.close
+
+# Run the query and return in the standar output the results
+# The first row and the last 3 rows are removed because contain
+# metainformation of the query not in CSV format
+`cat #{file.path} | sqlplus -S /nolog | sed '1d' | head -n -3 > #{destination_name}`
+file.unlink
+puts "[END] run-oracle-query/run.rb"


### PR DESCRIPTION
Runs a query in Oracle using `sqlplus` utility.

Usage:

`$DEV_DIR/gobierto-etl-utils/operations/run-oracle-query/run.rb "CONNECTION STRING" input.sql $WORKING_DIR/output.csv`

Where:

- first argument: the connection string
- second argument: a file with the query to execute
- third argument: the output file (in CSV format)