### PR TITLE
Tender dates

### DIFF
--- a/operations/gobierto_data/extract-contracts/query.sql
+++ b/operations/gobierto_data/extract-contracts/query.sql
@@ -27,7 +27,9 @@ SELECT
   categories.title as category_title,
   COALESCE(
     contracts.contract_award_published_at, contracts.contract_formalized_published_at, contracts.start_date
-  )::date AS award_date
+  )::date AS award_date,
+  tenders.open_proposals_date,
+  tenders.submission_date
 FROM
   contracts
   LEFT JOIN fiscal_entities contractors ON contractor_id = contractors.id

--- a/operations/gobierto_data/extract-contracts/schema.json
+++ b/operations/gobierto_data/extract-contracts/schema.json
@@ -21,5 +21,7 @@
   "cpvs":{"type":"text"},
   "category_id":{"type":"integer"},
   "category_title":{"type":"text"},
-  "award_date":{"type":"text"}
+  "award_date":{"type":"date"},
+  "open_proposals_date":{"type":"date"},
+  "submission_date":{"type":"date"}
 }


### PR DESCRIPTION
This PR adds tender columns open_proposals_date and submission_date to contracts dump in order to complete the Gobierto visualization of contracts (these attributes are being used in the contract info page)