### PR TITLE
Extract award and formalized dates

### DIFF
--- a/operations/gobierto_data/extract-contracts/query.sql
+++ b/operations/gobierto_data/extract-contracts/query.sql
@@ -48,9 +48,8 @@ SELECT
     WHEN 'textile' THEN 'Textil'
     WHEN 'transportation' THEN 'Transporte'
   END as category_title,
-  COALESCE(
-    contracts.contract_award_published_at, contracts.contract_formalized_published_at, contracts.start_date
-  )::date AS award_date,
+  contracts.contract_award_published_at::date AS award_date,
+  contracts.contract_formalized_published_at::date AS formalized_date,
   tenders.open_proposals_date,
   tenders.submission_date,
   tenders.number_of_proposals,

--- a/operations/gobierto_data/extract-contracts/schema.json
+++ b/operations/gobierto_data/extract-contracts/schema.json
@@ -22,6 +22,7 @@
   "category_id":{"type":"integer"},
   "category_title":{"type":"text"},
   "award_date":{"type":"date"},
+  "formalized_date":{"type":"date"},
   "open_proposals_date":{"type":"date"},
   "submission_date":{"type":"date"},
   "number_of_proposals":{"type":"integer"},


### PR DESCRIPTION
This PR implements part of https://github.com/PopulateTools/issues/issues/1204

The award_date field calculation has been replaced by the plain award date, and a new field with the formalized date has been added