### PR TITLE
Avoid sending null categories

### DIFF
--- a/operations/gobierto_data/extract-contracts/query.sql
+++ b/operations/gobierto_data/extract-contracts/query.sql
@@ -26,8 +26,8 @@ SELECT
     ELSE false
   END as minor_contract,
   array_to_string(contracts.cpvs, ',') AS cpvs,
-  categories.id as category_id,
-  categories.title as category_title,
+  COALESCE(categories.id, 23) as category_id,
+  COALESCE(categories.title, 'other') as category_title,
   contracts.contract_award_published_at::date AS award_date,
   contracts.contract_formalized_published_at::date AS formalized_date,
   contracts.gobierto_start_date AS gobierto_start_date,

--- a/operations/gobierto_data/extract-tenders/query.sql
+++ b/operations/gobierto_data/extract-tenders/query.sql
@@ -21,8 +21,8 @@ SELECT
   initial_amount_no_taxes,
   array_to_string(tenders.cpvs, ',') AS cpvs,
   process_types.text AS process_type,
-  categories.id as category_id,
-  categories.title as category_title
+  COALESCE(categories.id, 23) as category_id,
+  COALESCE(categories.title, 'other') as category_title
   FROM tenders
   LEFT JOIN fiscal_entities contractors ON contractor_id = contractors.id
   LEFT JOIN entity_types contractors_types ON contractors_types.id = contractors.entity_type


### PR DESCRIPTION
If the category is null, we send the title and id of the "other" category.