### PR TITLE
1141 modify check-csv to require csv more than 1 lines

### DIFF
--- a/operations/check-csv/run.rb
+++ b/operations/check-csv/run.rb
@@ -33,16 +33,16 @@ status = :success
 begin
   CSV.read(input_file, encoding: 'utf-8')
 rescue => e
-  status = :error_reading_spaces_separated
+  status = :error_reading_comma_separated
 end
 
-if status == :error_reading_spaces_separated
+if status == :error_reading_comma_separated
   begin
     CSV.read(input_file, col_sep: ";", encoding: "utf-8")
     status = :success
   rescue StandardError => e
     puts "Error: #{e.message}"
-    error = :error_reading_comma_separated
+    status = :error_reading_semicolon_separated
   end
 end
 

--- a/operations/check-csv/run.rb
+++ b/operations/check-csv/run.rb
@@ -15,6 +15,7 @@ require_relative "../../lib/gobierto_etl_utils"
 #   $DEV_DIR/gobierto-etl-utils/operations/check-csv/run.rb input.csv
 #
 
+
 if ARGV.length != 1
   raise "Review the arguments"
 end
@@ -27,27 +28,32 @@ unless File.file?(input_file)
   raise "File #{input_file} doesn't exist"
 end
 
-error = false
+status = :success
 
 begin
-  error = false
   CSV.read(input_file, encoding: 'utf-8')
-rescue
-  error = true
+rescue => e
+  status = :error_reading_spaces_separated
 end
 
-if error
+if status == :error_reading_spaces_separated
   begin
-    error = false
     CSV.read(input_file, col_sep: ";", encoding: "utf-8")
+    status = :success
   rescue StandardError => e
     puts "Error: #{e.message}"
-    error = true
+    error = :error_reading_comma_separated
   end
 end
 
-if error
-  puts "[ERROR] Invalid CSV format"
+if status == :success
+  if CSV.table(input_file).count < 2
+    status = :csv_without_lines
+  end
+end
+
+unless status == :success
+  puts "[ERROR] Invalid CSV format #{status}"
   exit(-1)
 end
 


### PR DESCRIPTION
add new require condition csv should have more than 1 line.




# how to should be tested
```
curl http://dadesobertes.mataro.cat/factura_2anys.csv -o factura_2anys.csv -s
cd gobierto-etl-utils
# full file
ruby operations/convert-to-utf8/run.rb  ../factura_2anys.csv ../factura_2anys_uft8.csv
ruby operations/check-csv/run.rb ../factura_2anys_uft8.csv
#   it should work
#   [START] check-csv/run.rb for file ../factura_2anys_uft8.csv
#   [END] check-csv/run.rb

head -n 0 ../factura_2anys_uft8.csv ../factura_2anys_uft8_empty.csv
ruby operations/check-csv/run.rb ../factura_2anys_uft8_empty.csv
# it should fail
#    [START] check-csv/run.rb for file ../factura_2anys_head_uft8_only_header.csv
#    [ERROR] Invalid CSV format csv_without_lines

head -n 1 ../factura_2anys_uft8.csv ../factura_2anys_uft8_headers.csv
ruby operations/check-csv/run.rb ../factura_2anys_uft8_headers.csv
# it should fail
#    [START] check-csv/run.rb for file ../factura_2anys_uft8_header.csv
#    [ERROR] Invalid CSV format csv_without_lines

```
