### PR TITLE
Add no-verify-options for broken certs

### DIFF
--- a/pipelines/datasets/contratos/Jenkinsfile
+++ b/pipelines/datasets/contratos/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
                   --gobierto-url $GOBIERTO_DATA_DEST_URL \
                   --schema-path ${ETL_UTILS}/operations/gobierto_data/extract-contracts/schema.json \
                   --file-url $FILEURL
+                  --no-verify-ssl
               '''
             }
         }

--- a/pipelines/datasets/licitaciones/Jenkinsfile
+++ b/pipelines/datasets/licitaciones/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
                   --gobierto-url $GOBIERTO_DATA_DEST_URL \
                   --schema-path ${ETL_UTILS}/operations/gobierto_data/extract-tenders/schema.json \
                   --file-url $FILEURL
+                  --no-verify-ssl
               '''
             }
         }


### PR DESCRIPTION
This PR is related with https://github.com/PopulateTools/gobierto-etl-alcobendas/pull/6/files and https://github.com/PopulateTools/ansible-populate/pull/269/files

adds the option no-verify-ssl to fix imports for sites with custom certs, such as Alcobendas