### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem "zeitwerk"
 gem "byebug"
 gem "nokogiri"
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "faraday"
 gem "rubyzip"
 gem "aws-sdk-s3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: f5c5b1b0846ded63e034edcda2edee425d9d72bd
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 17761ea394fdb07418ee89a751482da4c6ebdaaf
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -130,7 +130,7 @@ DEPENDENCIES
   aws-sdk-s3
   byebug
   faraday
-  gobierto_data!
+  gobierto_budgets_data!
   nokogiri
   pry
   rubyzip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Utilities for ETL scripts for Gobierto
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This gem relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This gem relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/operations/gobierto_budgets/bubbles/run.rb
+++ b/operations/gobierto_budgets/bubbles/run.rb
@@ -37,7 +37,7 @@ if organizations_ids.any?
 
   organizations_ids.each do |organization_id|
     puts " - Calculating bubbles for organization #{organization_id}"
-    GobiertoData::GobiertoBudgets::Bubbles.dump(organization_id)
+    GobiertoBudgetsData::GobiertoBudgets::Bubbles.dump(organization_id)
   end
 else
   puts "[SUMMARY] No organizations to calculate bubbles"

--- a/operations/gobierto_budgets/clear-budgets/run.rb
+++ b/operations/gobierto_budgets/clear-budgets/run.rb
@@ -24,16 +24,16 @@ ORGANIZATIONS_IDS_FILE_PATH = ARGV[0]
 year = ARGV[1]
 
 indices = [
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST,
-  GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED,
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
 ]
 
 types = [
-  GobiertoData::GobiertoBudgets::TOTAL_BUDGET_TYPE,
-  GobiertoData::GobiertoBudgets::ECONOMIC_BUDGET_TYPE,
-  GobiertoData::GobiertoBudgets::FUNCTIONAL_BUDGET_TYPE,
-  GobiertoData::GobiertoBudgets::CUSTOM_BUDGET_TYPE
+  GobiertoBudgetsData::GobiertoBudgets::TOTAL_BUDGET_TYPE,
+  GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_BUDGET_TYPE,
+  GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_BUDGET_TYPE,
+  GobiertoBudgetsData::GobiertoBudgets::CUSTOM_BUDGET_TYPE
 ]
 
 organizations_ids = []
@@ -73,14 +73,14 @@ organizations_ids.each do |organization_id|
   count = 0
   indices.each do |index|
     types.each do |type|
-      response = GobiertoData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
+      response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
       while response['hits']['total'] > 0
         delete_request_body = response['hits']['hits'].map do |h|
           count += 1
           { delete: h.slice("_index", "_type", "_id") }
         end
-        GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
-        response = GobiertoData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
+        GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
+        response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
       end
     end
   end

--- a/operations/gobierto_budgets/clear-previous-providers/run.rb
+++ b/operations/gobierto_budgets/clear-previous-providers/run.rb
@@ -19,8 +19,8 @@ if ARGV.length != 1
   raise "At least one argument is required"
 end
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_INVOICES
-type =  GobiertoData::GobiertoBudgets::INVOICE_TYPE
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_INVOICES
+type =  GobiertoBudgetsData::GobiertoBudgets::INVOICE_TYPE
 organization_id = ARGV[0].to_s
 
 puts "[START] clear-previous-providers/run.rb organization_id=#{organization_id}"
@@ -43,14 +43,14 @@ query = {
 }
 
 count = 0
-response = GobiertoData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
+response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
 while response['hits']['total'] > 0
   delete_request_body = response['hits']['hits'].map do |h|
     count += 1
     { delete: h.slice("_index", "_type", "_id") }
   end
-  GobiertoData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
-  response = GobiertoData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
+  GobiertoBudgetsData::GobiertoBudgets::SearchEngineWriting.client.bulk index: index, type: type, body: delete_request_body
+  response = GobiertoBudgetsData::GobiertoBudgets::SearchEngine.client.search index: index, type: type, body: query
 end
 
 puts "[END] clear-previous-providers/run.rb. Deleted #{count} items"

--- a/operations/gobierto_budgets/delete_total_budget/run.rb
+++ b/operations/gobierto_budgets/delete_total_budget/run.rb
@@ -27,9 +27,9 @@ ORGANIZATIONS_IDS_FILE_PATH = ARGV[1]
 puts "[START] delete_total_budgets/run.rb with years=#{YEARS} file=#{ORGANIZATIONS_IDS_FILE_PATH}"
 
 TOTAL_BUDGET_INDEXES = [
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST,
-  GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED,
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
 ].freeze
 
 organizations_ids = []
@@ -48,7 +48,7 @@ if organizations_ids.any?
       TOTAL_BUDGET_INDEXES.each do |index|
         puts " - Deleting totals for #{organization_id} in year #{year} for index #{index}"
 
-        total_budget_calculator = GobiertoData::GobiertoBudgets::TotalBudgetCalculator.new(
+        total_budget_calculator = GobiertoBudgetsData::GobiertoBudgets::TotalBudgetCalculator.new(
           organization_id: organization_id,
           year: year,
           index: index

--- a/operations/gobierto_budgets/import-executed-budgets/run.rb
+++ b/operations/gobierto_budgets/import-executed-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-executed-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-executed-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-invoices/run.rb
+++ b/operations/gobierto_budgets/import-invoices/run.rb
@@ -7,6 +7,6 @@ data_file = ARGV[0]
 
 puts "[START] import-invoices/run.rb data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::InvoicesImporter.new(data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::InvoicesImporter.new(data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-invoices/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-planned-budgets-updated/run.rb
+++ b/operations/gobierto_budgets/import-planned-budgets-updated/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-planned-budgets-updated/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-planned-budgets-updated/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/import-planned-budgets/run.rb
+++ b/operations/gobierto_budgets/import-planned-budgets/run.rb
@@ -3,12 +3,12 @@
 require "bundler/setup"
 Bundler.require
 
-index = GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST
+index = GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST
 data_file = ARGV[0]
 year = ARGV[1].to_i
 
 puts "[START] import-planned-budgets/run.rb year=#{year} data_file=#{data_file}"
 
-nitems = GobiertoData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
+nitems = GobiertoBudgetsData::GobiertoBudgets::BudgetLinesImporter.new(index: index, year: year, data: JSON.parse(File.read(data_file))).import!
 
 puts "[END] import-planned-budgets/run.rb imported #{nitems} items"

--- a/operations/gobierto_budgets/update_total_budget/run.rb
+++ b/operations/gobierto_budgets/update_total_budget/run.rb
@@ -27,9 +27,9 @@ ORGANIZATIONS_IDS_FILE_PATH = ARGV[1]
 puts "[START] update_total_budgets/run.rb with years=#{YEARS} file=#{ORGANIZATIONS_IDS_FILE_PATH}"
 
 TOTAL_BUDGET_INDEXES = [
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST,
-  GobiertoData::GobiertoBudgets::ES_INDEX_EXECUTED,
-  GobiertoData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_EXECUTED,
+  GobiertoBudgetsData::GobiertoBudgets::ES_INDEX_FORECAST_UPDATED
 ].freeze
 
 organizations_ids = []
@@ -48,7 +48,7 @@ if organizations_ids.any?
       TOTAL_BUDGET_INDEXES.each do |index|
         puts " - Calculating totals for #{organization_id} in year #{year} for index #{index}"
 
-        total_budget_calculator = GobiertoData::GobiertoBudgets::TotalBudgetCalculator.new(
+        total_budget_calculator = GobiertoBudgetsData::GobiertoBudgets::TotalBudgetCalculator.new(
           organization_id: organization_id,
           year: year,
           index: index

--- a/operations/gobierto_budgets/xbrl/penloc/transform-planned/run.rb
+++ b/operations/gobierto_budgets/xbrl/penloc/transform-planned/run.rb
@@ -51,7 +51,7 @@ puts "[START] transform-planned/run.rb with dictionary=#{xbrl_dictionary_path} d
 
 output_data = []
 if place = INE::Places::Place.find(organization_id)
-  population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+  population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
   base_data = {
     organization_id: organization_id,
     ine_code: place.id.to_i,
@@ -99,7 +99,7 @@ xbrl_budget_line_ids.each do |budget_line_id|
     next
   end
 
-  kind = (budget_line_info['kind'] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE)
+  kind = (budget_line_info['kind'] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
   code = budget_line_info['code']
   level = code.length
   next if level > 5

--- a/operations/gobierto_budgets/xbrl/trimloc/transform-execution/run.rb
+++ b/operations/gobierto_budgets/xbrl/trimloc/transform-execution/run.rb
@@ -42,7 +42,7 @@ puts "[START] transform-execution/run.rb with dictionary=#{xbrl_dictionary_path}
 
 output_data = []
 if place = INE::Places::Place.find(organization_id)
-  population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+  population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
   base_data = {
     organization_id: organization_id,
     ine_code: place.id.to_i,
@@ -88,7 +88,7 @@ xbrl_budget_line_ids.each do |budget_line_id|
 
   next if budget_line_info['code'].nil?
 
-  kind = (budget_line_info['kind'] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE)
+  kind = (budget_line_info['kind'] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
   code = budget_line_info['code']
   level = code.length
   next if level > 5

--- a/operations/gobierto_budgets/xbrl/trimloc/transform-planned-updated/run.rb
+++ b/operations/gobierto_budgets/xbrl/trimloc/transform-planned-updated/run.rb
@@ -42,7 +42,7 @@ puts "[START] transform-planned-updated/run.rb with dictionary=#{xbrl_dictionary
 
 output_data = []
 if place = INE::Places::Place.find(organization_id)
-  population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+  population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
   base_data = {
     organization_id: organization_id,
     ine_code: place.id.to_i,
@@ -80,7 +80,7 @@ xbrl_budget_line_ids.each do |budget_line_id|
 
   next if budget_line_info['code'].nil?
 
-  kind = (budget_line_info['kind'] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE)
+  kind = (budget_line_info['kind'] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
   code = budget_line_info['code']
   level = code.length
   next if level > 5

--- a/operations/gobierto_budgets/xbrl/trimloc/transform-planned/run.rb
+++ b/operations/gobierto_budgets/xbrl/trimloc/transform-planned/run.rb
@@ -45,7 +45,7 @@ puts "[START] transform-planned/run.rb with dictionary=#{xbrl_dictionary_path} d
 
 output_data = []
 if place = INE::Places::Place.find(organization_id)
-  population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+  population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
   base_data = {
     organization_id: organization_id,
     ine_code: place.id.to_i,
@@ -86,7 +86,7 @@ xbrl_budget_line_ids.each do |budget_line_id|
 
   next if budget_line_info['code'].nil?
 
-  kind = (budget_line_info['kind'] == 'I' ? GobiertoData::GobiertoBudgets::INCOME : GobiertoData::GobiertoBudgets::EXPENSE)
+  kind = (budget_line_info['kind'] == 'I' ? GobiertoBudgetsData::GobiertoBudgets::INCOME : GobiertoBudgetsData::GobiertoBudgets::EXPENSE)
   code = budget_line_info['code']
   level = code.length
   next if level > 5


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`