### PR TITLE
Change cache-clear operation to use a cache service accepting a site …

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ Output:
 
 ### gobierto/clear cache
 
-Clears rails cache.
+Clears rails cache of a site and module namespace.
 
 This operation is a Gobierto runner.
 
 Usage:
 
-`/path/to/gobierto bin runner ruby gobierto-etl-utils/operations/gobierto/clear-cache/run.rb`
+`/path/to/gobierto bin runner ruby gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-organization-id "INE_CODE" --namespace "GobiertoBudgets"`
 
 Output:
 

--- a/operations/gobierto/clear-cache/run.rb
+++ b/operations/gobierto/clear-cache/run.rb
@@ -3,21 +3,48 @@
 require "bundler/setup"
 Bundler.require
 
-# Usage:
-#
-#  - Must be ran as Rails runner of Gobierto
-#
-# Arguments:
-#
-#  - No arguments
-#
-# Samples:
-#
-#   /path/to/project/operations/gobierto/clear-cache/run.rb
-#
+# Clears cache for a site and namespace
 
-puts "[START] clear-cache/run.rb"
+if ARGV.length == 0
+  ARGV[0] = "-h"
+end
 
-Rails.cache.clear
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = <<-BANNER
+Clears cache for a site and namespace
+Usage: cd $DEV/gobierto; bin/rails runner $DEV/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb [options]
+
+       (*) site-organization-id or site-domain must be provided to find a site and namespace is required
+BANNER
+
+  opts.on("--site-organization-id SITE_ORGANIZATION_ID", "Site organization_id") do |v|
+    options[:organization_id] = v
+  end
+  opts.on("--site-domain SITE_DOMAIN", "Site domain") do |v|
+    options[:domain] = v
+  end
+  opts.on("--namespace NAMESPACE", "Cache namespace (for example: GobiertoData)") do |v|
+    options[:namespace] = v
+  end
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+puts "[START] clear-cache/run.rb with #{ARGV.join(' - ')}"
+
+site_options = options.slice(:organization_id, :domain).reject { |_, v| v.blank? }
+
+site = Site.find_by(**site_options)
+
+if site.blank?
+  raise "Site not found. Please provide a valid domain or organization_id"
+end
+
+cache_service = GobiertoCommon::CacheService.new(site, options[:namespace])
+cache_service.clear
 
 puts "[END] clear-cache/run.rb"


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR changes the cache-clear operation to accept arguments and call a cache service in Gobierto identified by site and namespace. The site can be provided by passing the organization_id or/and the domain:
* To pass the organization_id use `--site-organization-id` option
* To pass the domain use `--site_domain` option
* To pass the namespace use `--namespace` option. The namespace is a string representing a Gobierto module, for example `GobiertoData`