### PR TITLE
If the csv file has no lines, puts a warning message but allow execution.

### DIFF
--- a/operations/check-csv/run.rb
+++ b/operations/check-csv/run.rb
@@ -48,7 +48,7 @@ end
 
 if status == :success
   if CSV.table(input_file).count < 2
-    status = :csv_without_lines
+    puts "[WARNING] the CSV file has no content"
   end
 end
 


### PR DESCRIPTION
Related to gencat errors:

http://jenkins.populate.tools/job/gobierto-contratos%20import%20catalonia%20dataset%20(diff)/344/console