### PR TITLE
Generic budgets update task

### DIFF
--- a/operations/download-s3/run.rb
+++ b/operations/download-s3/run.rb
@@ -15,21 +15,23 @@ require "net/https"
 #
 #  - 0: S3 URI
 #  - 1: Output folder
+#  - 2: Output filename (optional)
 #
 # Samples:
 #
-#   /path/to/project/operations/download-s3/run.rb "getafe/providers" /tmp/foo
+#   /path/to/project/operations/download-s3/run.rb "getafe/providers" /tmp/foo [foo.txt]
 #
 
-if ARGV.length != 2
+if ARGV.length < 2 || ARGV.length > 3
   raise "Review the arguments"
 end
 
 folder = ARGV[0]
 destination_folder = ARGV[1]
+destination_file = ARGV[2]
 FileUtils.mkdir_p(destination_folder)
 
-puts "[START] download-s3/run.rb from #{folder} to #{destination_folder}"
+puts "[START] download-s3/run.rb from #{folder} to #{destination_folder}#{destination_file ? "/#{destination_file}" : ""}"
 
 s3 = Aws::S3::Resource.new(
   region: ENV.fetch("GOBIERTO_DATA_AWS_REGION"),
@@ -39,7 +41,7 @@ s3 = Aws::S3::Resource.new(
 
 objects = s3.bucket(ENV.fetch("GOBIERTO_DATA_S3_BUCKET_NAME")).objects(prefix: folder).each do |object|
   next if object.get.content_type == "application/x-directory"
-  destination_file = "#{destination_folder}/#{File.basename(object.public_url)}"
+  destination_file = "#{destination_folder}/#{destination_file || File.basename(object.public_url)}"
   puts "- Downloading #{object.public_url} in #{destination_file}"
   object.get(response_target: destination_file)
 end

--- a/pipelines/budgets/update_trimloc_xbrl/Jenkinsfile
+++ b/pipelines/budgets/update_trimloc_xbrl/Jenkinsfile
@@ -1,0 +1,89 @@
+
+email = "popu-servers+jenkins@populate.tools "
+pipeline {
+    agent any
+    environment {
+        PATH = "$HOME/.rbenv/shims:$PATH"
+        GOBIERTO_ETL_UTILS = "/var/www/gobierto-etl-utils/current"
+        WORKING_DIR = "/tmp/budgets_update_trimloc_xbrl/"
+        // Variables that must be defined via Jenkins UI:
+        // GOBIERTO = "/var/www/gobierto/current"
+        // FILE_PATH = "getafe/budgets/XX-TrimLoc-2020_9.xbrl"
+        // INE_CODE = "28065"
+        // YEAR = 2022
+    }
+    options {
+        retry(3)
+    }
+    stages {
+        stage('Remove working dir') {
+            steps {
+                sh "rm -rf ${WORKING_DIR}"
+            }
+        }
+        stage('Extract > Download data sources') {
+            steps {
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download-s3/run.rb '${FILE_PATH}' ${WORKING_DIR} ${YEAR}_${INE_CODE}.xbrl"
+            }
+        }
+        stage('Transform > Transform executed budgets files') {
+            steps {
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/xbrl/trimloc/transform-execution/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml ${WORKING_DIR}/${YEAR}_${INE_CODE}.xbrl ${INE_CODE} ${YEAR} ${WORKING_DIR}/budgets-execution-${YEAR}.json"
+            }
+        }
+       stage('Transform > Transform planned budgets files') {
+            steps {
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/xbrl/trimloc/transform-planned-updated/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/${YEAR}_${INE_CODE}.xbrl ${INE_CODE} ${YEAR} $WORKING_DIR/budgets-planned-updated-${YEAR}.json"
+            }
+        }
+        stage('Load > Import planned budget files') {
+            steps {
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-${YEAR}.json ${YEAR}"
+            }
+        }
+        stage('Load > Import executed budget files') {
+            steps {
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-execution-${YEAR}.json ${YEAR}"
+            }
+        }
+        stage('Load > Prepare Organization ids') {
+            steps {
+              sh "echo ${INE_CODE} > ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Load > Calculate totals') {
+            steps {
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '${YEAR}' ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Load > Calculate bubbles') {
+            steps {
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/bubbles/run.rb ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Load > Calculate annual data') {
+            steps {
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '${YEAR}' ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Load > Publish activity') {
+            steps {
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/publish-activity/run.rb budgets_updated ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Load > Reset cache') {
+            steps {
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${INE_CODE}' --namespace 'GobiertoBudgets'"
+            }
+        }
+    }
+    post {
+        failure {
+            echo 'This will run only if failed'
+            mail body: "Project: ${env.JOB_NAME} - Build Number: ${env.BUILD_NUMBER} - URL de build: ${env.BUILD_URL}",
+                charset: 'UTF-8',
+                subject: "ERROR CI: Project name -> ${env.JOB_NAME}",
+                to: email
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the XBRL update budgets task from ETL Getafe to this generic repo.

It also lets to run it on any INE CODE, not just Getafe, so it can be used with new customers without having to run any change in Ansible or Jenkins.