### PR TITLE
Clone dataset operation

### DIFF
--- a/lib/gobierto_data/client.rb
+++ b/lib/gobierto_data/client.rb
@@ -24,6 +24,16 @@ module GobiertoData
       self.auth_header = "Bearer #{params[:api_token]}"
     end
 
+    def metadata(dataset_slug)
+      response = connection.get(
+        "/api/v1/data/datasets/#{dataset_slug}/meta.json",
+        {},
+        build_dataset_request_headers(false)
+      )
+      log_response(response) if debug
+      response
+    end
+
     def create_dataset(params = {})
       multipart = params[:file_path].present? || params[:schema_path].present?
       response = connection(multipart).post(

--- a/lib/gobierto_data/client.rb
+++ b/lib/gobierto_data/client.rb
@@ -114,6 +114,7 @@ module GobiertoData
         append: params[:append] || false
       }
 
+      dataset_params.merge!({schema: params[:schema]}) if params[:schema]
       dataset_params.merge!({data_path: params[:file_url]}) if params[:file_url]
       dataset_params.merge!({data_file: Faraday::UploadIO.new(params[:file_path], "text/csv")}) if params[:file_path]
       dataset_params.merge!({schema_file: Faraday::UploadIO.new(params[:schema_path], "application/json")}) if params[:schema_path]

--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -22,12 +22,6 @@ Usage: ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/r
 
        (*) all parameters are required except those with default value
 
-ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb
-    --origin https://datos.gobierto.es/datos/tasa-natalidad
-    --origin-api-token xxxxx
-    --destination https://esplugues.gobify.net
-    --destination-api-token xxxxx
-    --ine-code 8077
 BANNER
 
   opts.on("--origin-api-token API_TOKEN", "Gobierto Data Origin API Token") do |v|
@@ -59,20 +53,6 @@ end.parse!
 
 puts "[START] upload-dataset/run.rb with #{ARGV.join(' - ')}"
 
-pp options
-
-# gobierto_data_client = GobiertoData::Client.new(options.slice(:api_token, :gobierto_url, :debug, :no_verify_ssl))
-# gobierto_data_client.upsert_dataset(options.except(:api_token, :gobierto_url, :debug))
-
-# ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb
-#     --origin https://datos.gobierto.es/datos/tasa-natalidad
-#     --origin-api-token xxxxx
-#     --destination https://esplugues.gobify.net
-#     --destination-api-token xxxxx
-
-# 0. Extract origin dataset slug (tasa-natalidad)
-# 1. Read origin dataset metadata
-#    GET https://datos.gobierto.es/api/v1/data/datasets/tasa-natalidad/meta.json
 origin_host = options[:origin].split("/")[0..2].join("/")
 
 client = GobiertoData::Client.new({
@@ -83,18 +63,12 @@ client = GobiertoData::Client.new({
 metadata = client.metadata(options[:origin].split('/').last)
 body = JSON.parse(metadata.body)
 
-# 2. Get dataset name
 name = body.dig("data", "attributes", "name")
-# 3. Get dataset slug
 slug = body.dig("data", "attributes", "slug")
-# 4. Get dataset table_name
 table_name = body.dig("data", "attributes", "table_name")
-# 5. Get dataset schema
-schema = body.dig("data", "attributes", "columns").to_json
-# 7. Build SQL query "SELECT * FROM tasa_natalidad WHERE place_id = 8077"
+schema = body.dig("data", "attributes", "columns")
 query = "SELECT * FROM #{table_name} WHERE place_id = #{options[:ine_code]}"
-# 8. Fill destination dataset options hash: name, slug, table_name, schema_path, file_url
-# 9. Create destination dataset
+
 client = GobiertoData::Client.new({
   api_token: options[:destination_api_token],
   gobierto_url: options[:destination],
@@ -105,16 +79,12 @@ params = {
   name: name,
   table_name: table_name,
   slug: slug,
-  local_data: false,
   visibility_level: 'active',
   csv_separator: ",",
   append: false,
   schema: schema,
-  data_path: "#{origin_host}/api/v1/data/data.csv?sql=#{CGI.escape(query)}&token=#{options[:origin_api_token]}",
+  file_url: "#{origin_host}/api/v1/data/data.csv?sql=#{CGI.escape(query)}&token=#{options[:origin_api_token]}",
 }
-pp params
 client.upsert_dataset(params)
-
-
 
 puts "[END] upload-dataset/run.rb"

--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -36,7 +36,7 @@ BANNER
   opts.on("--destination DESTINATION GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
     options[:destination] = v
   end
-  opts.on("--where-condition", "WHERE condition") do |v|
+  opts.on("--where-condition WHERE_CONDITION", "WHERE condition") do |v|
     options[:where_condition] = v
   end
   opts.on("--no-verify-ssl", "Skip SSL verification") do |v|

--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -36,7 +36,7 @@ BANNER
   opts.on("--destination DESTINATION GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
     options[:destination] = v
   end
-  opts.on("--where-contition", "WHERE contition") do |v|
+  opts.on("--where-condition", "WHERE condition") do |v|
     options[:where_condition] = v
   end
   opts.on("--no-verify-ssl", "Skip SSL verification") do |v|

--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -36,8 +36,8 @@ BANNER
   opts.on("--destination DESTINATION GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
     options[:destination] = v
   end
-  opts.on("--ine-code INE_CODE", "Place INE code") do |v|
-    options[:ine_code] = v
+  opts.on("--where-contition", "WHERE contition") do |v|
+    options[:where_condition] = v
   end
   opts.on("--no-verify-ssl", "Skip SSL verification") do |v|
     options[:no_verify_ssl] = true
@@ -67,7 +67,7 @@ name = body.dig("data", "attributes", "name")
 slug = body.dig("data", "attributes", "slug")
 table_name = body.dig("data", "attributes", "table_name")
 schema = body.dig("data", "attributes", "columns")
-query = "SELECT * FROM #{table_name} WHERE place_id = #{options[:ine_code]}"
+query = "SELECT * FROM #{table_name} WHERE #{options[:where_condition]}"
 
 client = GobiertoData::Client.new({
   api_token: options[:destination_api_token],

--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+require_relative "../../../lib/gobierto_etl_utils"
+
+# Clone a dataset from a Gobierto Data instance to another Gobierto Data instance
+if ARGV.length == 0
+  ARGV[0] = "-h"
+end
+
+options = {
+  debug: true,
+  csv_separator: ',',
+  append: false,
+  visibility_level: 'active',
+  no_verify_ssl: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<-BANNER
+Clone a dataset from a Gobierto Data instance to another Gobierto Data instance
+Usage: ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb [options]
+
+       (*) all parameters are required except those with default value
+
+ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb
+    --origin https://datos.gobierto.es/datos/tasa-natalidad
+    --origin-api-token xxxxx
+    --destination https://esplugues.gobify.net
+    --destination-api-token xxxxx
+    --ine-code 8077
+BANNER
+
+  opts.on("--origin-api-token API_TOKEN", "Gobierto Data Origin API Token") do |v|
+    options[:origin_api_token] = v
+  end
+  opts.on("--origin ORIGIN GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
+    options[:origin] = v
+  end
+  opts.on("--destination-api-token API_TOKEN", "Gobierto Data Destination API Token") do |v|
+    options[:destination_api_token] = v
+  end
+  opts.on("--destination DESTINATION GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
+    options[:destination] = v
+  end
+  opts.on("--ine-code INE_CODE", "Place INE code") do |v|
+    options[:ine_code] = v
+  end
+  opts.on("--no-verify-ssl", "Skip SSL verification") do |v|
+    options[:no_verify_ssl] = true
+  end
+  opts.on("-d", "--debug", "Run with debug mode enabled") do |v|
+    options[:debug] = v
+  end
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+puts "[START] upload-dataset/run.rb with #{ARGV.join(' - ')}"
+
+pp options
+
+# gobierto_data_client = GobiertoData::Client.new(options.slice(:api_token, :gobierto_url, :debug, :no_verify_ssl))
+# gobierto_data_client.upsert_dataset(options.except(:api_token, :gobierto_url, :debug))
+
+# ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb
+#     --origin https://datos.gobierto.es/datos/tasa-natalidad
+#     --origin-api-token xxxxx
+#     --destination https://esplugues.gobify.net
+#     --destination-api-token xxxxx
+
+# 0. Extract origin dataset slug (tasa-natalidad)
+# 1. Read origin dataset metadata
+#    GET https://datos.gobierto.es/api/v1/data/datasets/tasa-natalidad/meta.json
+origin_host = options[:origin].split("/")[0..2].join("/")
+
+client = GobiertoData::Client.new({
+  api_token: options[:origin_api_token],
+  gobierto_url: origin_host,
+  debug: true
+})
+metadata = client.metadata(options[:origin].split('/').last)
+body = JSON.parse(metadata.body)
+
+# 2. Get dataset name
+name = body.dig("data", "attributes", "name")
+# 3. Get dataset slug
+slug = body.dig("data", "attributes", "slug")
+# 4. Get dataset table_name
+table_name = body.dig("data", "attributes", "table_name")
+# 5. Get dataset schema
+schema = body.dig("data", "attributes", "columns").to_json
+# 7. Build SQL query "SELECT * FROM tasa_natalidad WHERE place_id = 8077"
+query = "SELECT * FROM #{table_name} WHERE place_id = #{options[:ine_code]}"
+# 8. Fill destination dataset options hash: name, slug, table_name, schema_path, file_url
+# 9. Create destination dataset
+client = GobiertoData::Client.new({
+  api_token: options[:destination_api_token],
+  gobierto_url: options[:destination],
+  debug: true
+})
+
+params = {
+  name: name,
+  table_name: table_name,
+  slug: slug,
+  local_data: false,
+  visibility_level: 'active',
+  csv_separator: ",",
+  append: false,
+  schema: schema,
+  data_path: "#{origin_host}/api/v1/data/data.csv?sql=#{CGI.escape(query)}&token=#{options[:origin_api_token]}",
+}
+pp params
+client.upsert_dataset(params)
+
+
+
+puts "[END] upload-dataset/run.rb"

--- a/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
+++ b/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         // ORIGIN_API_TOKEN = ""
         // DESTINATION_URL = ""
         // DESTINATION_API_TOKEN = ""
-        // INE_CODE = ""
+        // WHERE_CONDITION = ""
     }
     options {
         retry(3)
@@ -24,7 +24,7 @@ pipeline {
                   --origin-api-token $ORIGIN_API_TOKEN \
                   --destination $DESTINATION_URL \
                   --destination-api-token $DESTINATION_API_TOKEN \
-                  --ine-code $INE_CODE
+                  --where-condition $WHERE_CONDITION
               '''
             }
         }
@@ -39,4 +39,3 @@ pipeline {
         }
     }
 }
-

--- a/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
+++ b/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
@@ -1,0 +1,42 @@
+email = "popu-servers+jenkins@populate.tools "
+pipeline {
+    agent any
+    environment {
+        PATH = "$HOME/.rbenv/shims:$PATH"
+        ETL_UTILS = "/var/www/gobierto-etl-utils/current/"
+        // Variables that must be defined via Jenkins UI:
+        // ORIGIN_URL = ""
+        // ORIGIN_API_TOKEN = ""
+        // DESTINATION_URL = ""
+        // DESTINATION_API_TOKEN = ""
+        // INE_CODE = ""
+    }
+    options {
+        retry(3)
+    }
+    stages {
+        stage('Import contratos') {
+            steps {
+              sh '''#!/bin/bash
+                cd ${ETL_UTILS};
+                ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb \
+                  --origin $ORIGIN_URL \
+                  --origin-api-token $ORIGIN_API_TOKEN \
+                  --destination $DESTINATION_URL \
+                  --destination-api-token $DESTINATION_API_TOKEN \
+                  --ine-code $INE_CODE
+              '''
+            }
+        }
+    }
+    post {
+        failure {
+            echo 'This will run only if failed'
+            mail body: "Project: ${env.JOB_NAME} - Build Number: ${env.BUILD_NUMBER} - URL de build: ${env.BUILD_URL}",
+                charset: 'UTF-8',
+                subject: "ERROR CI: Project name -> ${env.JOB_NAME}",
+                to: email
+        }
+    }
+}
+

--- a/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
+++ b/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             steps {
               sh '''#!/bin/bash
                 cd ${ETL_UTILS};
-                ruby gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb \
+                ruby operations/gobierto_data/clone-dataset/run.rb \
                   --origin $ORIGIN_URL \
                   --origin-api-token $ORIGIN_API_TOKEN \
                   --destination $DESTINATION_URL \

--- a/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
+++ b/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             steps {
               sh '''#!/bin/bash
                 cd ${ETL_UTILS};
-                ruby $DEV_DIR/gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb \
+                ruby gobierto-etl-utils/operations/gobierto_data/clone-dataset/run.rb \
                   --origin $ORIGIN_URL \
                   --origin-api-token $ORIGIN_API_TOKEN \
                   --destination $DESTINATION_URL \


### PR DESCRIPTION
Closes #145 

This PR adds a new operation to create a dataset based on another Gobierto Data dataset.

This is very useful to extract a subset of rows of a Gobierto  dataset (i.e the rows of a municipality) and upload them to the municipality data portal.