### PR TITLE
clone dataset action

### DIFF
--- a/operations/gobierto_data/clone-dataset/run.rb
+++ b/operations/gobierto_data/clone-dataset/run.rb
@@ -36,8 +36,8 @@ BANNER
   opts.on("--destination DESTINATION GOBIERTO_URL", "Gobierto Data URL (protocol + host, i.e http://datos.gobierto.es/") do |v|
     options[:destination] = v
   end
-  opts.on("--ine-code INE_CODE", "Place INE code") do |v|
-    options[:ine_code] = v
+  opts.on("--where-contition", "WHERE contition") do |v|
+    options[:where_condition] = v
   end
   opts.on("--no-verify-ssl", "Skip SSL verification") do |v|
     options[:no_verify_ssl] = true
@@ -67,7 +67,7 @@ name = body.dig("data", "attributes", "name")
 slug = body.dig("data", "attributes", "slug")
 table_name = body.dig("data", "attributes", "table_name")
 schema = body.dig("data", "attributes", "columns")
-query = "SELECT * FROM #{table_name} WHERE place_id = #{options[:ine_code]}"
+query = "SELECT * FROM #{table_name} WHERE #{options[:where_condition]}"
 
 client = GobiertoData::Client.new({
   api_token: options[:destination_api_token],

--- a/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
+++ b/pipelines/datasets/gobierto_data_dataset/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         // ORIGIN_API_TOKEN = ""
         // DESTINATION_URL = ""
         // DESTINATION_API_TOKEN = ""
-        // INE_CODE = ""
+        // WHERE_CONDITION = ""
     }
     options {
         retry(3)
@@ -24,7 +24,7 @@ pipeline {
                   --origin-api-token $ORIGIN_API_TOKEN \
                   --destination $DESTINATION_URL \
                   --destination-api-token $DESTINATION_API_TOKEN \
-                  --ine-code $INE_CODE
+                  --where-condition $WHERE_CONDITION
               '''
             }
         }
@@ -39,4 +39,3 @@ pipeline {
         }
     }
 }
-


### PR DESCRIPTION
Closes #145 

This PR adds a new operation to create a dataset based on another Gobierto Data dataset.

This is very useful to extract a subset of rows of a Gobierto  dataset (i.e the rows of a municipality) and upload them to the municipality data portal.