### PR TITLE
extract zip operation

### DIFF
--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -27,8 +27,6 @@ Zip::File.open(zipfile_name) do |zip_file|
     # Handle entries one by one
     zip_file.each do |entry|
       puts "Extracting #{entry.name}"
-      raise 'File too large when extracted' if entry.size > MAX_SIZE
-  
       # Extract to file or directory based on name in the archive
       zip_file.extract(entry, destination_path)
     end

--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -1,0 +1,33 @@
+require 'zip'
+
+# Usage:
+#
+#  - Must be ran as an independent Ruby script
+#
+# Arguments:
+#
+#  - 0: Zipfile with extension (.zip)
+#
+# Samples:
+#
+#   /path/to/project/operations/extract-zip/run.rb /tmp/zipfile.zip
+#
+
+if ARGV.length < 1
+    raise "Review the arguments"
+  end
+
+zipfile_name  =  ARGV[0]
+
+Zip::File.open(zipfile_name) do |zip_file|
+    # Handle entries one by one
+    zip_file.each do |entry|
+      puts "Extracting #{entry.name}"
+      raise 'File too large when extracted' if entry.size > MAX_SIZE
+  
+      # Extract to file or directory based on name in the archive
+      entry.extract
+    end
+  end
+
+puts "[END] extract-zip/run.rb"

--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -7,10 +7,11 @@ require 'zip'
 # Arguments:
 #
 #  - 0: Zipfile with extension (.zip)
+#  - 1: Destination path
 #
 # Samples:
 #
-#   /path/to/project/operations/extract-zip/run.rb /tmp/zipfile.zip
+#   /path/to/project/operations/extract-zip/run.rb /tmp/zipfile.zip documents/tmp
 #
 
 if ARGV.length < 1

--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -23,6 +23,9 @@ if ARGV.length < 1
 zipfile_name  =  ARGV[0]
 destination_path = ARGV[1]
 
+Zip.on_exists_proc = true
+Zip.continue_on_exists_proc = true
+
 Zip::File.open(zipfile_name) do |zip_file|
     # Handle entries one by one
     zip_file.each do |entry|

--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -18,6 +18,7 @@ if ARGV.length < 1
   end
 
 zipfile_name  =  ARGV[0]
+destination_path = ARGV[1]
 
 Zip::File.open(zipfile_name) do |zip_file|
     # Handle entries one by one
@@ -26,7 +27,7 @@ Zip::File.open(zipfile_name) do |zip_file|
       raise 'File too large when extracted' if entry.size > MAX_SIZE
   
       # Extract to file or directory based on name in the archive
-      entry.extract
+      zip_file.extract(entry, destination_path)
     end
   end
 

--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -1,3 +1,5 @@
+require "bundler/setup"
+Bundler.require
 require 'zip'
 
 # Usage:


### PR DESCRIPTION
For [#1673 ](https://github.com/PopulateTools/issues/issues/1673)resolution, we need a new action for extracting zip contents.

# ✌️ What does this PR do?
Creates a new operation 'extract-zip' to extract content from a zip file.

# 🔍 How should this be manually tested?
Run the python script using: `ruby operations/extract-zip/run.rb documents/tmp/zipfile.zip`

