### PR TITLE
Extract zip operation

### DIFF
--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -27,12 +27,12 @@ Zip.on_exists_proc = true
 Zip.continue_on_exists_proc = true
 
 Zip::File.open(zipfile_name) do |zip_file|
-    # Handle entries one by one
-    zip_file.each do |entry|
-      puts "Extracting #{entry.name}"
-      # Extract to file or directory based on name in the archive
-      zip_file.extract(entry, destination_path)
-    end
+  # Handle entries one by one
+  zip_file.each do |entry|
+    puts "Extracting #{entry.name}"
+    # Extract to file or directory based on name in the archive
+    entry.extract(destination_path)
   end
+end
 
 puts "[END] extract-zip/run.rb"


### PR DESCRIPTION
For [#1673 ](https://github.com/PopulateTools/issues/issues/1673)resolution, we need a new action for extracting zip contents.

# ✌️ What does this PR do?
Fix the 'extract-zip' operation, to extract content from a zip file.

# 🔍 How should this be manually tested?
Run the python script using: `ruby operations/extract-zip/run.rb documents/tmp/zipfile.zip`
