### PR TITLE
Extract zip operation

### DIFF
--- a/operations/extract-zip/run.rb
+++ b/operations/extract-zip/run.rb
@@ -31,7 +31,7 @@ Zip::File.open(zipfile_name) do |zip_file|
   zip_file.each do |entry|
     puts "Extracting #{entry.name}"
     # Extract to file or directory based on name in the archive
-    entry.extract(destination_path)
+    entry.extract(destination_path + "/#{entry.name}")
   end
 end
 


### PR DESCRIPTION
For [#1673 ](https://github.com/PopulateTools/issues/issues/1673)resolution, we need a new action for extracting zip contents.

# ✌️ What does this PR do?
Fix the 'extract-zip' operation, to extract content from a zip file.

# 🔍 How should this be manually tested?
Run the python script using: `ruby operations/extract-zip/run.rb documents/tmp/zipfile.zip`
