### PR TITLE
Excel to csv / gem 'roo' - Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem "faraday-multipart"
 gem "rubyzip"
 gem "aws-sdk-s3"
 gem 'pry'
+gem "roo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
     rake (13.0.6)
+    roo (2.10.0)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     tzinfo (2.0.6)
@@ -120,6 +123,7 @@ DEPENDENCIES
   gobierto_budgets_data!
   nokogiri
   pry
+  roo
   rubyzip
   zeitwerk (~> 2.5.4)
 


### PR DESCRIPTION
In order to fix [ETL-UTILS/operations/excel-to-csv ](https://github.com/PopulateTools/gobierto-etl-utils/blob/master/operations/excel-to-csv/run.rb)I added gem `roo` to `Gemfile`.