### PR TITLE
Having no content raises an error

### DIFF
--- a/operations/check-csv/run.rb
+++ b/operations/check-csv/run.rb
@@ -50,7 +50,8 @@ end
 
 if status == :success
   if CSV.table(input_file, col_sep: separator, encoding: 'utf-8').count < 2
-    puts "[WARNING] the CSV file has no content"
+    puts "[ERROR] the CSV file has no content"
+    exit(-1)
   end
 end
 


### PR DESCRIPTION
This PR updates the check csv task to raise an error if the CSV checked is empty.

I'm not sure if some ETL's will start failing because of this change, but the expected dataset file should be a dataset with content.