### PR TITLE
Changing priority for dates in contracts

### DIFF
--- a/operations/gobierto_data/extract-contracts/query.sql
+++ b/operations/gobierto_data/extract-contracts/query.sql
@@ -30,7 +30,7 @@ SELECT
   COALESCE(categories.title, 'other') as category_title,
   contracts.contract_award_published_at::date AS award_date,
   contracts.contract_formalized_published_at::date AS formalized_date,
-  contracts.gobierto_start_date AS gobierto_start_date,
+  COALESCE(contracts.formalized_date, contracts.awarded_date, contracts.gobierto_start_date) AS gobierto_start_date,
   tenders.open_proposals_date,
   tenders.submission_date,
   tenders.contract_value AS estimated_value


### PR DESCRIPTION
Related to PopulateTools/gobierto-contratos#3399

Launched the change [on staging](http://jenkins-staging.populate.tools/job/gobierto-etl-ribaroja%20contratos%20dataset/360/console). Riba Roja contracts on gobify has the correct dates now:

- https://ribaroja.gobify.net/visualizaciones/contratos/adjudicaciones/2197024
- https://ribaroja.gobify.net/visualizaciones/contratos/adjudicaciones/2196998

After merge, lauched the jenkins task of riba-roja contracts should fix the issue.